### PR TITLE
fix: add additional valid intents

### DIFF
--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -34,6 +34,8 @@ var ValidIntents = []string{
 	"Created",
 	"Deleted",
 	"Updated",
+	"Snoozed",
+	"Unsnoozed",
 }
 
 func NonNullableArrayToStringArray(array *[]string) []string {


### PR DESCRIPTION
This allows for selecting Snoozed or Unsnoozed as an intent for routing. 